### PR TITLE
Bump User-Agent header

### DIFF
--- a/life360/api.py
+++ b/life360/api.py
@@ -31,7 +31,7 @@ _EXC_REPR_REDACTIONS = (
 )
 _LOGGER = logging.getLogger(__name__)
 
-USER_AGENT = "com.life360.android.safetymapd/KOKO/23.49.0 android/13"
+USER_AGENT = "com.life360.android.safetymapd/KOKO/23.50.0 android/13"
 CLIENT_TOKEN = (
     "Y2F0aGFwYWNyQVBoZUtVc3RlOGV2ZXZldnVjSGFmZVRydVl1Zn"
     "JhYzpkOEM5ZVlVdkE2dUZ1YnJ1SmVnZXRyZVZ1dFJlQ1JVWQ=="


### PR DESCRIPTION
Life360 mobile app has been updated to 23.50.0, this PR bumps the version in the user-agent.

As far as I can see, no further changes have been made to its API calls, although we do need to improve handling of users who have verified phone numbers.